### PR TITLE
Added new mergeSequence tests and fixed substrings in quality score check

### DIFF
--- a/nimblegen_heatseq/src/main/java/com/roche/heatseq/process/PrimerReadExtensionAndPcrDuplicateIdentification.java
+++ b/nimblegen_heatseq/src/main/java/com/roche/heatseq/process/PrimerReadExtensionAndPcrDuplicateIdentification.java
@@ -798,8 +798,8 @@ public class PrimerReadExtensionAndPcrDuplicateIdentification {
 
 			// use quality scores to resolve conflicts when merging content in the overlap region
 			for (int i = 0; i < overlapLength; i++) {
-				short upstreamQualityScoreAtPosition = BamFileUtil.getQualityScore(upstreamOverlapQuality.substring(i, i));
-				short downstreamQualityScoreAtPosition = BamFileUtil.getQualityScore(downstreamQuality.substring(i, i));
+				short upstreamQualityScoreAtPosition = BamFileUtil.getQualityScore(upstreamOverlapQuality.substring(i, i + 1));
+				short downstreamQualityScoreAtPosition = BamFileUtil.getQualityScore(downstreamQuality.substring(i, i + 1));
 				// a higher quality score indicates a smaller probability of error (source: http://www.illumina.com/truseq/quality_101/quality_scores.ilmn)
 				if (upstreamQualityScoreAtPosition >= downstreamQualityScoreAtPosition) {
 					overlappingSequenceBuilder.append(upstreamOverlapSequence.getCodeAt(i).toString());

--- a/nimblegen_heatseq/src/test/java/com/roche/heatseq/process/PrimerReadExtensionAndPcrDuplicateIdentificationTest.java
+++ b/nimblegen_heatseq/src/test/java/com/roche/heatseq/process/PrimerReadExtensionAndPcrDuplicateIdentificationTest.java
@@ -80,4 +80,44 @@ public class PrimerReadExtensionAndPcrDuplicateIdentificationTest {
 		assertEquals(mergeInformation.getMergedSequence(), new IupacNucleotideCodeSequence("AACCGGTC"));
 		assertEquals(mergeInformation.getMergedQuality(), "HHHHHHHH");
 	}
+
+	@Test(groups = { "unit" })
+	public void longerUpstreamOneTest() {
+		ISequence upstreamSequence = new IupacNucleotideCodeSequence("TAACCGGTCC");
+		String upstreamQuality = "HHHHHHHHHH";
+		ISequence downstreamSequence = new IupacNucleotideCodeSequence("AACCGGTC");
+		String downstreamQuality = "HHHHHHHH";
+		MergeInformation mergeInformation = PrimerReadExtensionAndPcrDuplicateIdentification.mergeSequences(false, upstreamSequence, downstreamSequence, upstreamQuality, downstreamQuality, 25, 26);
+		assertEquals(mergeInformation.getMergedSequence(), new IupacNucleotideCodeSequence("TAACCGGTCC"));
+		assertEquals(mergeInformation.getMergedQuality(), "HHHHHHHHHH");
+	}
+
+	// The following two tests are temporary placeholders to illustrate a type of problem data that can currently slip through the code without failing tests.
+	@Test(groups = { "unit" })
+	public void alignmentNotShiftedOneTest() {
+		// This test paired with the alignmentShiftedOneTest and this is supposed to show a baseline proper alignment.
+		ISequence upstreamSequence = new IupacNucleotideCodeSequence("TGGTGAACC");
+		String upstreamQuality = "FGBF1@3FF";
+		ISequence downstreamSequence = new IupacNucleotideCodeSequence("GGTGAACCGCAT");
+		String downstreamQuality = "GF1GGGCGGFC@";
+		MergeInformation mergeInformation = PrimerReadExtensionAndPcrDuplicateIdentification.mergeSequences(false, upstreamSequence, downstreamSequence, upstreamQuality, downstreamQuality, 82, 83);
+		assertEquals(mergeInformation.getMergedSequence(), new IupacNucleotideCodeSequence("TGGTGAACCGCAT"));
+		assertEquals(mergeInformation.getMergedQuality(), "FGFFGGGFGGFC@");
+	}
+
+	@Test(groups = { "unit" })
+	public void alignmentShiftedOneTest() {
+		// This test shows how the pair from the alignmentNotShiftedOneTest can produce incorrect merged output when the alignment starts get flipped, swapping upstream and downstream in the process.
+		ISequence upstreamSequence = new IupacNucleotideCodeSequence("GGTGAACCGCAT");
+		String upstreamQuality = "GF1GGGCGGFC@";
+		ISequence downstreamSequence = new IupacNucleotideCodeSequence("TGGTGAACC");
+		String downstreamQuality = "FGBF1@3FF";
+
+		MergeInformation mergeInformation = PrimerReadExtensionAndPcrDuplicateIdentification.mergeSequences(false, upstreamSequence, downstreamSequence, upstreamQuality, downstreamQuality, 82, 83);
+		// Note that this merge is incorrect biologically, it should actually be "GGTGAACCGCAT"
+		assertEquals(mergeInformation.getMergedSequence(), new IupacNucleotideCodeSequence("GGGGAACCGCAT"));
+		assertEquals(mergeInformation.getMergedQuality(), "GFGGGGCGGFC@");
+		// This test is a reference that will pass, and can be removed once we are sure we have fixed the underlying problem.
+	}
+
 }


### PR DESCRIPTION
Here is my fix to the quality score checking along with extra tests to the mergeSequence code.
The final two tests may be unorthodox, but I used them to make sure my understanding of the code was correct. When given pairs that have start positions that indicate an invalid alignment, the code will merge the out of phase sequence and quality strings without complaining.
